### PR TITLE
client: add API to fetch reviews

### DIFF
--- a/models/location.go
+++ b/models/location.go
@@ -44,27 +44,10 @@ type TripType struct {
 	LocalizedName string `json:"localized_name,omitempty"`
 }
 
-// Review information about a single review
-type Review struct {
-	ID             string `json:"id,omitempty"`
-	LanguageCode   string `json:"lang,omitempty"`
-	LocationID     string `json:"location_id,omitempty"`
-	PublishedDate  string `json:"published_date,omitempty"`
-	Rating         int    `json:"rating,omitempty"`
-	HelpfulVotes   string `json:"helpful_votes,omitempty"`
-	RatingImageURL string `json:"rating_image_url,omitempty"`
-	URL            string `json:"url,omitempty"`
-	TripType       string `json:"trip_type,omitempty"`
-	TravelDate     string `json:"travel_date,omitempty"`
-	Content        string `json:"text,omitempty"`
-	User           *User  `json:"user,omitempty"`
-	Title          string `json:"title,omitempty"`
-}
-
 // User information about the user who wrote the review
 type User struct {
-	Username     string        `json:"username,omitempty"`
-	UserLocation *UserLocation `json:"user_location,omitempty"`
+	Username     string       `json:"username,omitempty"`
+	UserLocation UserLocation `json:"user_location,omitempty"`
 }
 
 // UserLocation information about a user's location.

--- a/models/review.go
+++ b/models/review.go
@@ -1,0 +1,23 @@
+package models
+
+// ReviewResponse represents a response from the review endpoint.
+type ReviewResponse struct {
+	Data []*Review `json:"data,omitempty"`
+}
+
+// Review information about a single review
+type Review struct {
+	ID             string `json:"id,omitempty"`
+	LanguageCode   string `json:"lang,omitempty"`
+	LocationID     string `json:"location_id,omitempty"`
+	PublishedDate  string `json:"published_date,omitempty"`
+	Rating         int    `json:"rating,omitempty"`
+	HelpfulVotes   string `json:"helpful_votes,omitempty"`
+	RatingImageURL string `json:"rating_image_url,omitempty"`
+	URL            string `json:"url,omitempty"`
+	TripType       string `json:"trip_type,omitempty"`
+	TravelDate     string `json:"travel_date,omitempty"`
+	Text           string `json:"text,omitempty"`
+	User           User  `json:"user,omitempty"`
+	Title          string `json:"title,omitempty"`
+}

--- a/tripadvisor_test.go
+++ b/tripadvisor_test.go
@@ -2,10 +2,15 @@ package tripadvisor
 
 import (
 	"context"
+	"os"
 	"testing"
 )
 
-func TestLocation(t *testing.T) {
+func TestLocation_valid(t *testing.T) {
+	apiKey := os.Getenv("TRIPADVISOR_APIKEY")
+	if apiKey == "" {
+		t.Skipf("No TRIPADVISOR_APIKEY set")
+	}
 	t.Parallel()
 	for _, tc := range []struct {
 		name       string
@@ -34,12 +39,61 @@ func TestLocation(t *testing.T) {
 
 			// Create a new instance
 			tripAdvisor := New(
-				SetKey("XXXXXXXXXXXXXXXXXXXXXX"),
+				SetKey(apiKey),
 				SetLanguageCode(tc.langCode),
 			)
 			_, err := tripAdvisor.Location(context.Background(), tc.locationID)
 			if err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestLocation_invalidKey(t *testing.T) {
+	tripAdvisor := New(
+		SetKey("invalid_key"),
+		SetLanguageCode("en_UK"),
+	)
+	_, err := tripAdvisor.Location(context.Background(), 3539289)
+	if err == nil {
+		t.Error("Expected error to be returned.")
+	}
+	if err, ok := err.(*ErrorResponse); !ok {
+		t.Errorf("Expected an ErrorResponse error; got %#v.", err)
+	}
+}
+
+func TestReviews_valid(t *testing.T) {
+	apiKey := os.Getenv("TRIPADVISOR_APIKEY")
+	if apiKey == "" {
+		t.Skipf("No TRIPADVISOR_APIKEY set")
+	}
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		locationID int
+		langCode   string
+	}{
+		{
+			name:       "Valid Hotel",
+			locationID: 302546,
+			langCode:   "en_UK",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tripAdvisor := New(
+				SetKey(apiKey),
+				SetLanguageCode(tc.langCode),
+			)
+			got, err := tripAdvisor.Reviews(context.Background(), tc.locationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Data) != 5 {
+				t.Errorf("Expected 5 reviews; got %#v.", got)
 			}
 		})
 	}


### PR DESCRIPTION
This extends the client to call the reviews endpoint to fetch
full reviews for a given location. It also improves the error handling.